### PR TITLE
Fix support for loading resource with base url

### DIFF
--- a/src/monaco/kusto_monaco_editor.ts
+++ b/src/monaco/kusto_monaco_editor.ts
@@ -10,7 +10,7 @@ function link(scope, elem, attrs) {
   const containerDiv = elem.find('#content')[0];
 
   if (!(global as any).monaco) {
-    (global as any).System.import(`/${scope.pluginBaseUrl}/lib/monaco.min.js`).then(() => {
+    (global as any).System.import(`./${scope.pluginBaseUrl}/lib/monaco.min.js`).then(() => {
       setTimeout(() => {
         initMonaco(containerDiv, scope);
       }, 1);


### PR DESCRIPTION
This PR fixes loading the _monaco.min.js_ for Log Analytics when running Grafana with a non default root_url configuration.